### PR TITLE
feat: limit Events and State Views for public demo

### DIFF
--- a/04-boundless-typescript/frontend/src/pages/EventsPage.tsx
+++ b/04-boundless-typescript/frontend/src/pages/EventsPage.tsx
@@ -26,6 +26,7 @@ const EVENT_COLORS: Record<string, string> = {
 export default function EventsPage() {
   const [events, setEvents] = useState<StoredEvent[]>([]);
   const [totalEvents, setTotalEvents] = useState(0);
+  const [shownEvents, setShownEvents] = useState(0);
   const [loading, setLoading] = useState(true);
   const [filterType, setFilterType] = useState<string>('');
   const [filterKey, setFilterKey] = useState<string>('');
@@ -35,8 +36,9 @@ export default function EventsPage() {
     try {
       const res = await fetch(`${BASE}/debug-events`);
       const data = await res.json();
-      setEvents(data);
-      setTotalEvents(data.length);
+      setEvents(data.events ?? data);
+      setTotalEvents(data.total ?? (data.events ?? data).length);
+      setShownEvents((data.events ?? data).length);
     } catch {
       // ignore
     } finally {
@@ -66,7 +68,7 @@ export default function EventsPage() {
     <div className="page" style={{ maxWidth: 1100 }}>
       <h1>📜 Events</h1>
       <p className="subtitle">
-        Live event stream — <strong>{totalEvents}</strong> events total
+        Showing last <strong>{shownEvents}</strong> of <strong>{totalEvents}</strong> events
       </p>
 
       <div className="explorer-tabs">

--- a/04-boundless-typescript/frontend/src/pages/InfoPage.tsx
+++ b/04-boundless-typescript/frontend/src/pages/InfoPage.tsx
@@ -79,7 +79,7 @@ export default function InfoPage() {
             both documentation and test cases.
           </p>
           <p>
-            <a href="https://giraflow.dev/app#https://raw.githubusercontent.com/SBortz/understanding-eventsourcing-dotnet/refs/heads/feat/boundless-typescript/04-boundless-typescript/shopping.giraflow.json" target="_blank" rel="noopener noreferrer">
+            <a href="https://giraflow.dev/app#https://raw.githubusercontent.com/SBortz/understanding-eventsourcing-dotnet/refs/heads/main/04-boundless-typescript/shopping.giraflow.json" target="_blank" rel="noopener noreferrer">
               🔗 View the Shopping Cart Event Model on giraflow.dev
             </a>
           </p>
@@ -131,10 +131,12 @@ export default function InfoPage() {
           <h2>🏗️ Architecture</h2>
           <div className="info-code">
             <ul>
-              <li><strong>Backend:</strong> Express + TypeScript + BoundlessDB (SQLite)</li>
+              <li><strong>Hosting:</strong> Vercel (Serverless Functions) + Supabase (PostgreSQL)</li>
+              <li><strong>Backend:</strong> TypeScript + BoundlessDB (PostgresStorage)</li>
               <li><strong>Frontend:</strong> React 19 + Vite + React Router</li>
               <li><strong>Pattern:</strong> Decider Pattern — each command handler reads events, builds state, validates, produces new events</li>
-              <li><strong>Storage:</strong> Single SQLite file (<code>shopping-cart.db</code>), persistent across restarts</li>
+              <li><strong>Hexagonal:</strong> Shared usecases, switchable heads (Express for local dev, Vercel Functions for production)</li>
+              <li><strong>Storage:</strong> Supabase PostgreSQL — BoundlessDB uses SERIALIZABLE transactions for multi-node safety</li>
               <li><strong>No ORM, no separate DB:</strong> Events are the single source of truth</li>
             </ul>
           </div>
@@ -143,7 +145,7 @@ export default function InfoPage() {
         <section className="info-section">
           <h2>📂 Source Code</h2>
           <p>
-            <a href="https://github.com/SBortz/understanding-eventsourcing-dotnet/tree/feat/boundless-typescript/04-boundless-typescript" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/SBortz/understanding-eventsourcing-dotnet/tree/main/04-boundless-typescript" target="_blank" rel="noopener noreferrer">
               🔗 GitHub: SBortz/understanding-eventsourcing-dotnet
             </a>
           </p>

--- a/04-boundless-typescript/frontend/src/pages/StateViewsPage.tsx
+++ b/04-boundless-typescript/frontend/src/pages/StateViewsPage.tsx
@@ -22,6 +22,8 @@ interface StateView {
   orders: Array<{ cartId: string; totalPrice: number; orderedProducts: Array<{ productId: string; totalPrice: number }> }>;
   prices: Record<string, number>;
   carts: Record<string, CartView>;
+  totalCarts: number;
+  totalOrders: number;
   totalEvents: number;
 }
 
@@ -70,7 +72,7 @@ export default function StateViewsPage() {
         {/* CartItemsStateView per cart */}
         <div className="state-card wide">
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <h3 style={{ margin: 0 }}>🛒 CartItemsStateView ({Object.keys(state.carts).length} carts)</h3>
+            <h3 style={{ margin: 0 }}>🛒 CartItemsStateView ({Object.keys(state.carts).length}{state.totalCarts > Object.keys(state.carts).length ? ` of ${state.totalCarts}` : ''} carts)</h3>
             <div className="cart-filter-toggle">
               <button
                 className={`cart-filter-btn ${cartFilter === 'all' ? 'active' : ''}`}
@@ -153,7 +155,7 @@ export default function StateViewsPage() {
 
         {/* Orders */}
         <div className="state-card wide">
-          <h3>📋 OrdersSV ({state.orders.length})</h3>
+          <h3>📋 OrdersSV ({state.orders.length}{state.totalOrders > state.orders.length ? ` of ${state.totalOrders}` : ''})</h3>
           {state.orders.length === 0 ? (
             <p className="state-empty">No orders yet</p>
           ) : (


### PR DESCRIPTION
Limits display for when many visitors use the public demo.

### Changes
- **Events page**: Shows last 100 events (subtitle: *Showing last 100 of N*)
- **State Views**: Carts limited to 50 newest, Orders limited to 50 newest
- **Totals shown** when truncated: *CartItemsStateView (50 of 200 carts)*
- **Inventories/Prices** unaffected (always small, one entry per product)

### Why
Public demo will have many users creating carts — without limits the Events and State Views pages would grow unbounded.