### PR TITLE
feat: use store.all().read() API for reading all events

### DIFF
--- a/04-boundless-typescript/package-lock.json
+++ b/04-boundless-typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "boundlessdb": "^0.6.0",
+        "boundlessdb": "^0.7.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "pg": "^8.13.1"
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/boundlessdb": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.6.0.tgz",
-      "integrity": "sha512-OuZGGKBBP2+wTflhNOWkTddxSTcG4S+tDnMUNRBZo0GHO0sY7pVqB12B2NzM0uV/u5XFVKOTrQjbku4XQuY5gA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.7.0.tgz",
+      "integrity": "sha512-gDpPkXFYQMOoKZK30nWoArb1jJZaJet7onLWP3YCoW2dGm2DHVgOSNwggLWJm2Pwa8j8hp3zI6RFhrbmkNlZnA==",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/04-boundless-typescript/package.json
+++ b/04-boundless-typescript/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "boundlessdb": "^0.6.0",
+    "boundlessdb": "^0.7.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "pg": "^8.13.1"

--- a/04-boundless-typescript/src/slices/explorer.ts
+++ b/04-boundless-typescript/src/slices/explorer.ts
@@ -1,4 +1,3 @@
-import { ALL_EVENT_TYPES } from '../domain/events.js';
 import { getStore, consistency } from '../store/setup.js';
 import { projectOrders } from './orders.js';
 import { projectCurrentPrices } from './change-price.js';
@@ -19,9 +18,7 @@ function getNestedValue(obj: unknown, path: string): unknown {
 
 export async function getDebugEvents(limit = 100) {
   const store = await getStore();
-  const result = await store.read({
-    conditions: ALL_EVENT_TYPES.map(type => ({ type })),
-  });
+  const result = await store.all().read();
 
   // Take only the last N events (newest first for display)
   const latest = result.events.slice(-limit);
@@ -51,9 +48,7 @@ export async function getDebugEvents(limit = 100) {
 
 export async function getDebugState(cartLimit = 50, orderLimit = 50) {
   const store = await getStore();
-  const result = await store.read({
-    conditions: ALL_EVENT_TYPES.map(type => ({ type })),
-  });
+  const result = await store.all().read();
 
   const allTyped = result.events.map(e => ({ type: e.type, data: e.data }) as any);
 

--- a/04-boundless-typescript/src/store/helpers.ts
+++ b/04-boundless-typescript/src/store/helpers.ts
@@ -1,7 +1,6 @@
 // Helper functions for reading/writing events with BoundlessDB
 
 import type { ShoppingEvent } from '../domain/events.js';
-import { ALL_EVENT_TYPES } from '../domain/events.js';
 import { getStore } from './setup.js';
 
 /**
@@ -64,9 +63,7 @@ export async function readEventsByType(type: string): Promise<ShoppingEvent[]> {
  */
 export async function readAllEvents(): Promise<ShoppingEvent[]> {
   const store = await getStore();
-  const result = await store.read({
-    conditions: ALL_EVENT_TYPES.map(type => ({ type })),
-  });
+  const result = await store.all().read();
   return result.events.map(toShoppingEvent);
 }
 


### PR DESCRIPTION
## Summary

Replaces the `ALL_EVENT_TYPES.map(type => ({ type }))` pattern with BoundlessDB 0.7.0's new `store.all().read()` API for reading the global event stream.

## Changes

- **`src/store/helpers.ts`**: `readAllEvents()` now uses `store.all().read()`
- **`src/slices/explorer.ts`**: `getDebugEvents()` and `getDebugState()` now use `store.all().read()`
- Removed `ALL_EVENT_TYPES` imports where no longer needed
- Updated `boundlessdb` dependency to `^0.7.0`

## What's NOT changed

- `readCartEvents()` / `readCartEventsWithCondition()` — key-based queries, unchanged
- `readEventsByType()` — single type query, unchanged
- `ALL_EVENT_TYPES` export in `domain/events.ts` — kept as-is

## Tests

All 22 tests pass ✅
Frontend builds cleanly ✅