### PR TITLE
feat: upgrade to BoundlessDB v0.9.0

### DIFF
--- a/04-boundless-typescript/package-lock.json
+++ b/04-boundless-typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "boundlessdb": "^0.7.0",
+        "boundlessdb": "^0.9.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "pg": "^8.13.1"
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/boundlessdb": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.7.0.tgz",
-      "integrity": "sha512-gDpPkXFYQMOoKZK30nWoArb1jJZaJet7onLWP3YCoW2dGm2DHVgOSNwggLWJm2Pwa8j8hp3zI6RFhrbmkNlZnA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.9.0.tgz",
+      "integrity": "sha512-62uRUP0ekoXvRy3GG5t/om6UbUf55xo8vccjXMaKYjNYhka9iThnS3qELl4icF1xhUKjt5vRdVpDyP2V8u7r6A==",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/04-boundless-typescript/package.json
+++ b/04-boundless-typescript/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "boundlessdb": "^0.7.0",
+    "boundlessdb": "^0.9.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "pg": "^8.13.1"

--- a/04-boundless-typescript/src/store/setup.ts
+++ b/04-boundless-typescript/src/store/setup.ts
@@ -1,7 +1,7 @@
 // BoundlessDB Event Store setup
 
 import { EventStore } from 'boundlessdb';
-import type { ConsistencyConfig, StorageInterface } from 'boundlessdb';
+import type { ConsistencyConfig, EventStorage } from 'boundlessdb';
 
 /**
  * Consistency config: defines which keys are extracted from each event type.
@@ -49,9 +49,9 @@ export const consistency: ConsistencyConfig = {
 };
 
 let storeInstance: EventStore | null = null;
-let storagePromise: Promise<StorageInterface> | null = null;
+let storagePromise: Promise<EventStorage> | null = null;
 
-async function createStorage(): Promise<StorageInterface> {
+async function createStorage(): Promise<EventStorage> {
   const pgUrl = process.env.POSTGRES_URL;
   if (pgUrl) {
     // Dynamic import: avoids loading better-sqlite3 on Vercel


### PR DESCRIPTION
## Changes

`matchKey()` vereinfacht die Cart-Queries massiv:

**Vorher** (8 Event Types manuell auflisten):
```ts
const result = await store.read({
  conditions: ['CartCreated', 'ItemAdded', 'ItemRemoved', 'ItemArchived',
    'CartSubmitted', 'CartCleared', 'CartPublished', 'CartPublicationFailed']
    .map(type => ({ type, key: 'cart', value: cartId })),
});
```

**Nachher** (eine Zeile):
```ts
const result = await store.query<ShoppingEvent>()
  .matchKey('cart', cartId)
  .read();
```

- `readCartEvents`: `matchKey('cart', cartId)`
- `readEventsByType`: `store.query().matchType(type)`
- `StorageInterface` → `EventStorage` (renamed in v0.9.0)
- 22 tests passing