### PR TITLE
fix: DCB concurrency for inventory and archive processor

### DIFF
--- a/04-boundless-typescript/package-lock.json
+++ b/04-boundless-typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "boundlessdb": "^0.9.0",
+        "boundlessdb": "^0.10.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "pg": "^8.13.1"
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/boundlessdb": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.9.0.tgz",
-      "integrity": "sha512-62uRUP0ekoXvRy3GG5t/om6UbUf55xo8vccjXMaKYjNYhka9iThnS3qELl4icF1xhUKjt5vRdVpDyP2V8u7r6A==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.10.0.tgz",
+      "integrity": "sha512-+OxX5aiXXEKvDWRI+ap+eFX3mQWVzqZjGdZhTeT0TyS3T3GDKCH/bB6pCganvG1/odUcsr122PBe/ht2iLr03Q==",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/04-boundless-typescript/package.json
+++ b/04-boundless-typescript/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "boundlessdb": "^0.9.0",
+    "boundlessdb": "^0.10.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "pg": "^8.13.1"

--- a/04-boundless-typescript/src/store/helpers.ts
+++ b/04-boundless-typescript/src/store/helpers.ts
@@ -41,6 +41,20 @@ export async function readEventsByType(type: string): Promise<ShoppingEvent[]> {
 }
 
 /**
+ * Read events by type and return the appendCondition for concurrency.
+ */
+export async function readEventsByTypeWithCondition(type: string) {
+  const store = await getStore();
+  const result = await store.query<ShoppingEvent>()
+    .matchType(type)
+    .read();
+  return {
+    events: result.events.map(toShoppingEvent),
+    appendCondition: result.appendCondition,
+  };
+}
+
+/**
  * Read all events (global stream)
  */
 export async function readAllEvents(): Promise<ShoppingEvent[]> {


### PR DESCRIPTION
## Fixes

### 1. submitCart — Inventory with appendCondition
Previously: `appendEvents(inventoryUpdates)` used blind append (`null` condition).
Now: `readEventsByTypeWithCondition('InventoryChanged')` + append with `appendCondition`.
Prevents race condition when two users buy the last item simultaneously.

### 3. changePrice — Archive Processor with appendCondition
Previously: `store.append(archiveEvents, null)` — blind append.
Now: Uses `readCartEventsWithCondition(cartId)` and appends `ItemArchived` with `appendCondition`.
Prevents archiving items that the user already removed.

Both follow the DCB Read-Decide-Append pattern from [dcb.events/examples](https://dcb.events/examples/).