### PR TITLE
feat: upgrade to boundlessdb@0.12.1

### DIFF
--- a/04-boundless-typescript/package-lock.json
+++ b/04-boundless-typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "boundlessdb": "^0.11.0",
+        "boundlessdb": "^0.12.1",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "pg": "^8.13.1"
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/boundlessdb": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.11.0.tgz",
-      "integrity": "sha512-EPXfDElbqAk3lKo/QKs7R60BeAO6ygZIjaiNsU/iCd2Ewx/fLxQAGw7GzYy5sJBgJO8PjgpUQDDjQ8oK92JaGQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/boundlessdb/-/boundlessdb-0.12.1.tgz",
+      "integrity": "sha512-K8ln6Uwo5Nbcw41oujprAqtCfQ5rsFkCGWyKdrE1f3eRcNBWmZIOuvxUg/eVI/xVZ0U04UiYMgu0YS19uItXLQ==",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/04-boundless-typescript/package.json
+++ b/04-boundless-typescript/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "boundlessdb": "^0.11.0",
+    "boundlessdb": "^0.12.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "pg": "^8.13.1"

--- a/04-boundless-typescript/src/store/helpers.ts
+++ b/04-boundless-typescript/src/store/helpers.ts
@@ -5,12 +5,12 @@ import { getStore } from './setup.js';
 
 /**
  * Read all events for a specific cart (by cart key).
- * Uses matchKey — no need to list every event type manually.
+ * Uses matchKeys — no need to list every event type manually.
  */
 export async function readCartEvents(cartId: string): Promise<ShoppingEvent[]> {
   const store = await getStore();
   const result = await store.query<ShoppingEvent>()
-    .matchKey('cart', cartId)
+    .matchKeys({ cart: cartId })
     .read();
   return result.events.map(toShoppingEvent);
 }
@@ -21,7 +21,7 @@ export async function readCartEvents(cartId: string): Promise<ShoppingEvent[]> {
 export async function readCartEventsWithCondition(cartId: string) {
   const store = await getStore();
   const result = await store.query<ShoppingEvent>()
-    .matchKey('cart', cartId)
+    .matchKeys({ cart: cartId })
     .read();
   return {
     events: result.events.map(toShoppingEvent),


### PR DESCRIPTION
- `matchKey('cart', cartId)` → `matchKeys({ cart: cartId })`
- boundlessdb bumped to ^0.12.1
- Tests passing